### PR TITLE
Instructions to prevent name collisions

### DIFF
--- a/netaddr_calc.sh
+++ b/netaddr_calc.sh
@@ -349,6 +349,19 @@ mac_is_bcast()
     _mac_is_mask "$1" 255.255.255.255.255.255
 }
 
+# mac_bool_bcast MAC
+# Test if a MAC address is broadcast.
+# P: MAC = a MAC address (in any format accepted by mac_to_bytes)
+# O: "true" if MAC is a broadcast address, "false" otherwise
+mac_bool_bcast()
+{
+    if mac_is_bcast "$1"; then
+        echo true
+    else
+        echo false
+    fi
+}
+
 # mac_is_mcast MAC
 # Test if a MAC address is multicast.
 # P: MAC = a MAC address (in any format accepted by mac_to_bytes)
@@ -356,6 +369,20 @@ mac_is_bcast()
 mac_is_mcast()
 {
     _mac_is_mask "$1" 1.0.0.0.0.0
+}
+
+# mac_bool_mcast MAC
+# Test if a MAC address is multicast.
+# P: MAC = a MAC address (in any format accepted by mac_to_bytes)
+# O: "true" if MAC is a multicast (including broadcast) address,
+#    "false" otherwise
+mac_bool_mcast()
+{
+    if mac_is_mcast "$1"; then
+        echo true
+    else
+        echo false
+    fi
 }
 
 # mac_is_universal MAC
@@ -367,12 +394,26 @@ mac_is_universal()
     ! _mac_is_mask "$1" 2.0.0.0.0.0
 }
 
+# mac_bool_universal MAC
+# Test if a MAC address is universally or locally administered.
+# P: MAC = a MAC address (in any format accepted by mac_to_bytes)
+# O: "true" if MAC is a universally administered,
+#    "false" if locally administered
+mac_bool_universal()
+{
+    if mac_is_universal "$1"; then
+        echo true
+    else
+        echo false
+    fi
+}
+
 # mac_set_bits MAC UNIVERSAL MCAST
 # Set special bits in a MAC address.
 # P: MAC = a MAC address (in any format accepted by mac_to_bytes)
-#    UNIVERSAL = sets the address as universally (0) or locally (1)
-#                administered; other values do not modify the universal/local
-#                bit
+#    UNIVERSAL = sets the address as universally (0 or "true") or locally (1 or
+#                "false") administered; other values do not modify the
+#                universal/local bit
 #    MCAST = sets the address as multicast (0) or unicast (1); other values
 #            do not modify the multicast/unicast bit
 # O: the modified MAC address (in format of mac_from_bytes)
@@ -384,8 +425,8 @@ mac_set_bits()
     m="$3"
     mac=`mac_to_bytes "$mac"`
     case "$u" in
-        0) mac=`bytes_and $mac 253.255.255.255.255.255`;;
-        1) mac=`bytes_or $mac 2.0.0.0.0.0`;;
+        0|true) mac=`bytes_and $mac 253.255.255.255.255.255`;;
+        1|false) mac=`bytes_or $mac 2.0.0.0.0.0`;;
     esac
     case "$m" in
         0) mac=`bytes_or $mac 1.0.0.0.0.0`;;

--- a/netaddr_calc.sh
+++ b/netaddr_calc.sh
@@ -1,5 +1,8 @@
 # Include this file into a shell (/bin/sh) script by
 # . netaddr_calc.sh
+# If the file cannot be directly included due to colliding names of functions,
+# it is possible to call functions defined in it like
+# ( . netaddr_calc.sh; FUNCTION1 [ARGS1...]; FUNCTION2 [ARGS2...]; ... )
 
 # In documentation comments of functions, P = parameters, O = stdout,
 # E = stderr, R = return value (exit status, 0 if unspecified)

--- a/netaddr_calc.sh
+++ b/netaddr_calc.sh
@@ -432,8 +432,8 @@ mac_set_bits()
         1|false) mac=`bytes_or $mac 2.0.0.0.0.0`;;
     esac
     case "$m" in
-        0) mac=`bytes_or $mac 1.0.0.0.0.0`;;
-        1) mac=`bytes_and $mac 254.255.255.255.255.255`;;
+        0|true) mac=`bytes_or $mac 1.0.0.0.0.0`;;
+        1|false) mac=`bytes_and $mac 254.255.255.255.255.255`;;
     esac
     echo `mac_from_bytes $mac`
 }

--- a/netaddr_calc.sh
+++ b/netaddr_calc.sh
@@ -290,7 +290,7 @@ ipv6_combine()
 }
 
 # ipv6_eui64 MAC
-# Generate a local part of an IPv6 address from a MAC address
+# Generate a link-local IPv6 address from a MAC address
 # P: MAC = a MAC address (in any format accepted by mac_to_bytes)
 # O: an IPv6 address with upper 64 bits set to zero and lower 64 bits generated
 #    from MAC according to EUI-64
@@ -301,7 +301,7 @@ ipv6_eui64()
     ! mac_is_universal "$mac"
     mac=`mac_set_bits $mac $?`
     mac=`mac_to_bytes $mac`
-    ipv6_from_bytes 0.0.0.0.0.0.0.0.${mac%.*.*.*}.255.254.${mac#*.*.*.}
+    ipv6_from_bytes 254.128.0.0.0.0.0.0.${mac%.*.*.*}.255.254.${mac#*.*.*.}
 }
 
 # ipv6_eui64_to_mac IP

--- a/netaddr_calc_test.sh
+++ b/netaddr_calc_test.sh
@@ -354,7 +354,7 @@ test_ipv6()
         2001:470:6f:ca1::1 fe80::b902:d4b4:a9cb:75c6 ffff:ffff:ffff::
 
     run_test ipv6_eui64_1 ipv6_eui64 0 \
-        ::7285:c2ff:fe78:8752 70:85:c2:78:87:52
+        fe80::7285:c2ff:fe78:8752 70:85:c2:78:87:52
 
     run_test ipv6_eui64_to_mac_1 ipv6_eui64_to_mac 0 \
         70:85:c2:78:87:52 fe80::7285:c2ff:fe78:8752

--- a/netaddr_calc_test.sh
+++ b/netaddr_calc_test.sh
@@ -424,28 +424,52 @@ test_mac()
         ff:ff:ff:ff:ff:ff ff:ff:ff:ff:ff:ff '' ''
     run_test mac_set_bits_u_mf_0 mac_set_bits 0 \
         00:00:00:00:00:00 00:00:00:00:00:00 '' '1'
+    run_test mac_set_bits_u_mfalse_0 mac_set_bits 0 \
+        00:00:00:00:00:00 00:00:00:00:00:00 '' false
     run_test mac_set_bits_u_mf_1 mac_set_bits 0 \
         02:00:00:00:00:00 03:00:00:00:00:00 '' '1'
+    run_test mac_set_bits_u_mfalse_1 mac_set_bits 0 \
+        02:00:00:00:00:00 03:00:00:00:00:00 '' false
     run_test mac_set_bits_u_mf_ff mac_set_bits 0 \
         fe:ff:ff:ff:ff:ff ff:ff:ff:ff:ff:ff '' '1'
+    run_test mac_set_bits_u_mfalse_ff mac_set_bits 0 \
+        fe:ff:ff:ff:ff:ff ff:ff:ff:ff:ff:ff '' false
     run_test mac_set_bits_u_mt_0 mac_set_bits 0 \
         01:00:00:00:00:00 00:00:00:00:00:00 '' '0'
+    run_test mac_set_bits_u_mtrue_0 mac_set_bits 0 \
+        01:00:00:00:00:00 00:00:00:00:00:00 '' true
     run_test mac_set_bits_u_mt_1 mac_set_bits 0 \
         03:00:00:00:00:00 03:00:00:00:00:00 '' '0'
+    run_test mac_set_bits_u_mtrue_1 mac_set_bits 0 \
+        03:00:00:00:00:00 03:00:00:00:00:00 '' true
     run_test mac_set_bits_u_mt_ff mac_set_bits 0 \
         ff:ff:ff:ff:ff:ff ff:ff:ff:ff:ff:ff '' '0'
+    run_test mac_set_bits_u_mtrue_ff mac_set_bits 0 \
+        ff:ff:ff:ff:ff:ff ff:ff:ff:ff:ff:ff '' true
     run_test mac_set_bits_uf_m_0 mac_set_bits 0 \
         02:00:00:00:00:00 00:00:00:00:00:00 '1' ''
+    run_test mac_set_bits_ufalse_m_0 mac_set_bits 0 \
+        02:00:00:00:00:00 00:00:00:00:00:00 false ''
     run_test mac_set_bits_uf_m_1 mac_set_bits 0 \
         03:00:00:00:00:00 03:00:00:00:00:00 '1' ''
+    run_test mac_set_bits_ufalse_m_1 mac_set_bits 0 \
+        03:00:00:00:00:00 03:00:00:00:00:00 false ''
     run_test mac_set_bits_uf_m_ff mac_set_bits 0 \
         ff:ff:ff:ff:ff:ff ff:ff:ff:ff:ff:ff '1' ''
+    run_test mac_set_bits_ufalse_m_ff mac_set_bits 0 \
+        ff:ff:ff:ff:ff:ff ff:ff:ff:ff:ff:ff false ''
     run_test mac_set_bits_ut_m_0 mac_set_bits 0 \
         00:00:00:00:00:00 00:00:00:00:00:00 '0' ''
+    run_test mac_set_bits_utrue_m_0 mac_set_bits 0 \
+        00:00:00:00:00:00 00:00:00:00:00:00 true ''
     run_test mac_set_bits_ut_m_1 mac_set_bits 0 \
         01:00:00:00:00:00 03:00:00:00:00:00 '0' ''
+    run_test mac_set_bits_utrue_m_1 mac_set_bits 0 \
+        01:00:00:00:00:00 03:00:00:00:00:00 true ''
     run_test mac_set_bits_ut_m_ff mac_set_bits 0 \
         fd:ff:ff:ff:ff:ff ff:ff:ff:ff:ff:ff '0' ''
+    run_test mac_set_bits_utrue_m_ff mac_set_bits 0 \
+        fd:ff:ff:ff:ff:ff ff:ff:ff:ff:ff:ff true ''
     run_test mac_set_bits_uf_mf_0 mac_set_bits 0 \
         02:00:00:00:00:00 00:00:00:00:00:00 '1' '1'
     run_test mac_set_bits_uf_mf_1 mac_set_bits 0 \

--- a/netaddr_calc_test.sh
+++ b/netaddr_calc_test.sh
@@ -381,6 +381,10 @@ test_mac()
     run_test mac_is_bcast_f_1 mac_is_bcast 1 '' ff:00:00:00:00:00
     run_test mac_is_bcast_t mac_is_bcast 0 '' ff:ff:ff:ff:ff:ff
 
+    run_test mac_bool_bcast_f_0 mac_bool_bcast 0 false 00:00:00:00:00:00
+    run_test mac_bool_bcast_f_1 mac_bool_bcast 0 false ff:00:00:00:00:00
+    run_test mac_bool_bcast_t mac_bool_bcast 0 true ff:ff:ff:ff:ff:ff
+
     run_test mac_is_mcast_f_0 mac_is_mcast 1 '' 00:00:00:00:00:00
     run_test mac_is_mcast_f_1 mac_is_mcast 1 '' 0e:00:00:00:00:00
     run_test mac_is_mcast_t_1 mac_is_mcast 0 '' 01:00:00:00:00:00
@@ -388,12 +392,29 @@ test_mac()
     run_test mac_is_mcast_t_2 mac_is_mcast 0 '' 01:a0:1b:cd:34:ef
     run_test mac_is_mcast_t_ff mac_is_mcast 0 '' ff:ff:ff:ff:ff:ff
 
+    run_test mac_bool_mcast_f_0 mac_bool_mcast 0 false 00:00:00:00:00:00
+    run_test mac_bool_mcast_f_1 mac_bool_mcast 0 false 0e:00:00:00:00:00
+    run_test mac_bool_mcast_t_1 mac_bool_mcast 0 true 01:00:00:00:00:00
+    run_test mac_bool_mcast_f_2 mac_bool_mcast 0 false fe:a0:1b:cd:34:ef
+    run_test mac_bool_mcast_t_2 mac_bool_mcast 0 true 01:a0:1b:cd:34:ef
+    run_test mac_bool_mcast_t_ff mac_bool_mcast 0 true ff:ff:ff:ff:ff:ff
+
     run_test mac_is_universal_t_0 mac_is_universal 0 '' 00:00:00:00:00:00
     run_test mac_is_universal_f_0 mac_is_universal 1 '' 02:00:00:00:00:00
     run_test mac_is_universal_t_1 mac_is_universal 0 '' 0d:00:00:00:00:00
     run_test mac_is_universal_f_1 mac_is_universal 1 '' 0f:00:00:00:00:00
     run_test mac_is_universal_t_2 mac_is_universal 0 '' fd:a0:1b:cd:34:ef
     run_test mac_is_universal_f_2 mac_is_universal 1 '' 72:a0:1b:cd:34:ef
+
+    run_test mac_bool_universal_t_0 mac_bool_universal 0 true 00:00:00:00:00:00
+    run_test mac_bool_universal_f_0 mac_bool_universal 0 false \
+        02:00:00:00:00:00
+    run_test mac_bool_universal_t_1 mac_bool_universal 0 true 0d:00:00:00:00:00
+    run_test mac_bool_universal_f_1 mac_bool_universal 0 false \
+        0f:00:00:00:00:00
+    run_test mac_bool_universal_t_2 mac_bool_universal 0 true fd:a0:1b:cd:34:ef
+    run_test mac_bool_universal_f_2 mac_bool_universal 0 false \
+        72:a0:1b:cd:34:ef
 
     run_test mac_set_bits_u_m_0 mac_set_bits 0 \
         00:00:00:00:00:00 00:00:00:00:00:00 '' ''


### PR DESCRIPTION
- Added a comment about preventing name collisions
- Generating a link-local address by ipv6_eui64
- `mac_bool_*` as variants of `mac_is_*` that use stdout instead of the exit status for the return value